### PR TITLE
Fix javadoc warnings/errors

### DIFF
--- a/src/main/java/eu/emi/security/authn/x509/X509Credential.java
+++ b/src/main/java/eu/emi/security/authn/x509/X509Credential.java
@@ -48,16 +48,19 @@ public interface X509Credential
 	
 	/**
 	 * Helper method to get private key from the underlying keystore
+	 * @return private key
 	 */
 	public PrivateKey getKey();
 
 	/**
 	 * Helper method to get certificate from the underlying keystore
+	 * @return certificate
 	 */
 	public X509Certificate getCertificate();
 
 	/**
  	 * Helper method to get certificate chain from the underlying keystore
+	 * @return certificate chain
 	 */
 	public X509Certificate[] getCertificateChain();
 	

--- a/src/main/java/eu/emi/security/authn/x509/helpers/CachedPEMReader.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/CachedPEMReader.java
@@ -38,7 +38,7 @@ public class CachedPEMReader extends PEMParser
 	/**
 	 * Generate BC's PemObject from the input stream. 
 	 * @return the parsed PEM object
-	 * @throws IOException
+	 * @throws IOException IO exception
 	 */
 	@Override
 	public PemObject readPemObject() throws IOException

--- a/src/main/java/eu/emi/security/authn/x509/helpers/CertificateHelpers.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/CertificateHelpers.java
@@ -191,7 +191,7 @@ public class CertificateHelpers
 	 * Converts certificates array to {@link CertPath}
 	 * @param in array
 	 * @return converted object
-	 * @throws CertificateException
+	 * @throws CertificateException certificate exception
 	 */
 	public static CertPath toCertPath(X509Certificate[] in) throws CertificateException
 	{
@@ -249,6 +249,7 @@ public class CertificateHelpers
 	 * The check is done only for known types of keys - RSA and DSA currently.
 	 * @param privKey first key to match
 	 * @param pubKey 2nd key to match
+	 * @throws InvalidKeyException invalid key exception
 	 */
 	public static void checkKeysMatching(PrivateKey privKey, PublicKey pubKey) throws InvalidKeyException
 	{

--- a/src/main/java/eu/emi/security/authn/x509/helpers/FlexiblePEMReader.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/FlexiblePEMReader.java
@@ -18,7 +18,7 @@ import org.bouncycastle.util.io.pem.PemObject;
 
 
 /**
- * Extends BC's {@link PEMReader} class so it can read correctly also 
+ * Extends BC's {@link PEMParser} class so it can read correctly also 
  * PEM files with a garbage at the beginning 
  * and minor syntax violations which occur more then often in the wild. 
  *
@@ -40,7 +40,7 @@ public class FlexiblePEMReader extends PEMParser
 	/**
 	 * Generate BC's PemObject
 	 * @return the parsed PEM object
-	 * @throws IOException
+	 * @throws IOException IO exception
 	 */
 	@Override
 	public PemObject readPemObject() throws IOException

--- a/src/main/java/eu/emi/security/authn/x509/helpers/JavaAndBCStyle.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/JavaAndBCStyle.java
@@ -170,7 +170,7 @@ public class JavaAndBCStyle extends BCStyle
 	
 	/**
 	 * 
-	 * @param name
+	 * @param name name
 	 * @return String representation with human readable labels for all attributes known by the JDK.
 	 */
 	@Override
@@ -181,7 +181,7 @@ public class JavaAndBCStyle extends BCStyle
 
 	/**
 	 * 
-	 * @param name
+	 * @param name name
 	 * @return String representation with human readable labels for all known attributes.
 	 */
 	public String toStringFull(X500Name name)
@@ -191,7 +191,7 @@ public class JavaAndBCStyle extends BCStyle
 	
 	/**
 	 * 
-	 * @param oid
+	 * @param oid oid
 	 * @return String label for the oid if it is known by the JDK
 	 */
 	public String getLabelForOid(ASN1ObjectIdentifier oid)
@@ -201,7 +201,7 @@ public class JavaAndBCStyle extends BCStyle
 
 	/**
 	 * 
-	 * @param oid
+	 * @param oid oid
 	 * @return String label for the oid if it is among all known attributes
 	 */
 	public String getLabelForOidFull(ASN1ObjectIdentifier oid)

--- a/src/main/java/eu/emi/security/authn/x509/helpers/PKCS8DERReader.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/PKCS8DERReader.java
@@ -14,7 +14,7 @@ import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
 
 /**
- * This class extends the {@link PEMReader} class from the BC library.
+ * This class extends the {@link PEMParser} class from the BC library.
  * It is modified to read DER input, not the PEM (it can be considered a smart-hack)
  * as otherwise BC's parsers code would need to be copied. It supports reading of the
  * PKCS8 private key in DER form. It is assumed that the key is encrypted if 
@@ -44,7 +44,7 @@ public class PKCS8DERReader extends PEMParser
 	 * Generate BC's PemObject from the input stream. The object's type is 
 	 * fixed to encrypted or plain private key.
 	 * @return the parsed PEM object
-	 * @throws IOException
+	 * @throws IOException IO exception
 	 */
 	@Override
 	public PemObject readPemObject() throws IOException

--- a/src/main/java/eu/emi/security/authn/x509/helpers/crl/LazyOpensslCRLStoreSpi.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/crl/LazyOpensslCRLStoreSpi.java
@@ -52,9 +52,11 @@ public class LazyOpensslCRLStoreSpi extends AbstractCRLStoreSPI
 
 	/**
 	 * Creates a new CRL store.
-	 * @param params
-	 * @param observers
-	 * @throws InvalidAlgorithmParameterException
+	 * @param path path
+	 * @param crlUpdateInterval crl update interval
+	 * @param observers observers handler
+	 * @param openssl1Mode openssl 1 mode
+	 * @throws InvalidAlgorithmParameterException invalid algorithm parameter exception
 	 */
 	public LazyOpensslCRLStoreSpi(String path, long crlUpdateInterval, ObserversHandler observers,
 			boolean openssl1Mode) throws InvalidAlgorithmParameterException

--- a/src/main/java/eu/emi/security/authn/x509/helpers/crl/PlainCRLStoreSpi.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/crl/PlainCRLStoreSpi.java
@@ -45,7 +45,7 @@ import eu.emi.security.authn.x509.impl.CRLParameters;
  * (i.e. is not an absolute URL) then it can contain wildcard characters ('*', '?'). 
  * In case of wildcard locations, the actual file list is regenerated on each update.
  * <p>
- * All CRLs are loaded and parsed to establish CA->CRL mapping. This mapping is updated
+ * All CRLs are loaded and parsed to establish CA-&gt;CRL mapping. This mapping is updated
  * after the updateInterval time is passed.
  * <p>
  * Faulty CRL locations together with the respective errors can be obtained 
@@ -79,10 +79,10 @@ public class PlainCRLStoreSpi extends AbstractCRLStoreSPI
 
 	/**
 	 * Creates a new CRL store. The store will be empty until the {@link #start()} method is called.
-	 * @param params
-	 * @param t
-	 * @param observers
-	 * @throws InvalidAlgorithmParameterException
+	 * @param params CRL parameters
+	 * @param t timer
+	 * @param observers observers handler
+	 * @throws InvalidAlgorithmParameterException invalid algorithm parameter exception
 	 */
 	public PlainCRLStoreSpi(CRLParameters params, Timer t, ObserversHandler observers) 
 			throws InvalidAlgorithmParameterException

--- a/src/main/java/eu/emi/security/authn/x509/helpers/ns/AbstractNamespacesStore.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/ns/AbstractNamespacesStore.java
@@ -75,8 +75,8 @@ public abstract class AbstractNamespacesStore implements NamespacesStore
 	 * Adds a given policy to a given map. It is assumed that the map is indexed by issuer hash
 	 * and the value maps are indexed by issuer id.
 	 * This method is useful only for stores which keep all their namespaces in memory.
-	 * @param policy
-	 * @param policies
+	 * @param policy policy to add
+	 * @param policies policy map to add to
 	 */
 	protected void addPolicy(NamespacePolicy policy, Map<String, Map<String, List<NamespacePolicy>>> policies)
 	{
@@ -95,8 +95,8 @@ public abstract class AbstractNamespacesStore implements NamespacesStore
 	
 	/**
 	 * Adds policy to a map indexed by a policy issuer.
-	 * @param policy
-	 * @param map
+	 * @param policy policy to add
+	 * @param map policy map to add to
 	 */
 	protected void addPolicyToMap(NamespacePolicy policy, Map<String, List<NamespacePolicy>> map)
 	{
@@ -124,12 +124,12 @@ public abstract class AbstractNamespacesStore implements NamespacesStore
 	 * Utility method useful for lazy stores. Retrieves a cached policies for the given ca hash and issuer. 
 	 * If there is no policy in the cache then it is tried to load one from disk. The 
 	 * loaded policy is cached before being returned. 
-	 * @param policies
-	 * @param definedForHash
-	 * @param issuer
-	 * @param path
-	 * @param maxTTL
-	 * @return
+	 * @param policies policies
+	 * @param definedForHash defined for hash
+	 * @param issuer issuer
+	 * @param path path
+	 * @param maxTTL max TTL
+	 * @return cached policies
 	 */
 	protected List<NamespacePolicy> getCachedPolicies(Map<String, CachedElement<Map<String, List<NamespacePolicy>>>> policies,
 			String definedForHash, String issuer, String path, long maxTTL)

--- a/src/main/java/eu/emi/security/authn/x509/helpers/ns/NamespaceChecker.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/ns/NamespaceChecker.java
@@ -62,6 +62,7 @@ public class NamespaceChecker
 	 * Self signed certificates in the chain are ignored, so the root CA certificate may be safely 
 	 * present in the chain. 
 	 * @param chain to be checked
+	 * @return list of validation errors
 	 */
 	public List<ValidationError> check(X509Certificate[] chain)
 	{

--- a/src/main/java/eu/emi/security/authn/x509/helpers/ns/NamespacesStore.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/ns/NamespacesStore.java
@@ -26,17 +26,17 @@ public interface NamespacesStore
 	 * Gets namespace policies applicable for the CA. The CA must be present in the cert chain, 
 	 * at the position given. The subsequent chain elements might be used if there is no explicit policy
 	 * defined for the CA itself: then it is checked if any of the parent CAs defined policy for this CA.
-	 * @param chain
-	 * @param position
-	 * @return
+	 * @param chain chain
+	 * @param position position
+	 * @return policies
 	 */
 	public List<NamespacePolicy> getPolicies(X509Certificate[] chain, int position); 
 
 	/**
 	 * As {@link #getPolicies(X509Certificate[], int)} but with principals of certificates only
-	 * @param chain
-	 * @param position
-	 * @return
+	 * @param chain chain
+	 * @param position position
+	 * @return policies
 	 */
 	public List<NamespacePolicy> getPolicies(X500Principal[] chain, int position); 
 }

--- a/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/AbstractValidator.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/AbstractValidator.java
@@ -65,6 +65,7 @@ public abstract class AbstractValidator implements X509CertChainValidatorExt
 	 * This is not a cleanest design possible but it is required as arguments to the init()
 	 * method require some code to be created in subclasses. Therefore we have a trade off:
 	 * a bit unclean design inside the library and a clean external API without factory methods.
+	 * @param initialListeners initial listeners
 	 */
 	public AbstractValidator(Collection<? extends StoreUpdateListener> initialListeners)
 	{
@@ -75,6 +76,10 @@ public abstract class AbstractValidator implements X509CertChainValidatorExt
 	/**
 	 * Use this method to initialize the parent from the extension class, if not using
 	 * the non-default constructor.
+	 * @param caStore CA store
+	 * @param crlStore CRL store
+	 * @param proxySupport proxy support
+	 * @param revocationCheckingMode revocation checking mode
 	 */
 	protected synchronized void init(TrustAnchorStore caStore, AbstractCRLStoreSPI crlStore, 
 			ProxySupport proxySupport, RevocationParameters revocationCheckingMode)
@@ -174,7 +179,7 @@ public abstract class AbstractValidator implements X509CertChainValidatorExt
 
 	/**
 	 * Notifies all registered listeners.
-	 * @param error
+	 * @param error validation error
 	 * @return true if the error should be ignored false otherwise.
 	 */
 	protected boolean notifyListeners(ValidationError error)

--- a/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/BCCertPathValidator.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/BCCertPathValidator.java
@@ -99,6 +99,12 @@ public class BCCertPathValidator
 	 * </ul>
 	 * 
 	 * @param toCheck chain to check
+	 * @param proxySupport proxy support
+	 * @param trustAnchors trust anchors
+	 * @param crlStore crl store
+	 * @param revocationParams revocation params
+	 * @param observersHandler observers handler
+	 * @return validation result
 	 * @throws CertificateException if some of the certificates in the chain can not 
 	 * be parsed
 	 */
@@ -260,12 +266,14 @@ public class BCCertPathValidator
 	 * Performs checking of the chain which has no proxies (or at least should not have proxies),
 	 * using {@link FixedBCPKIXCertPathReviewer}. In future, when BC implementation is fixed
 	 * it should use {@link PKIXCertPathReviewer} instead.  
-	 * @param baseChain
-	 * @param params
-	 * @param errors
-	 * @param unresolvedExtensions
+	 * @param baseChain base chain
+	 * @param params parameters
+	 * @param errors errors
+	 * @param unresolvedExtensions unresolved extensions
+	 * @param posDelta position delta
+	 * @param cc certificate chain
 	 * @return validated chain or null
-	 * @throws CertificateException
+	 * @throws CertificateException certificate exception
 	 */
 	protected List<X509Certificate> checkNonProxyChain(X509Certificate[] baseChain, 
 			ExtPKIXParameters params, List<ValidationError> errors, 
@@ -345,10 +353,11 @@ public class BCCertPathValidator
 	 * EEC issuer is used as the only trust anchor. CRLs are ignored, proxy extension OIDs 
 	 * are marked as handled. The error resulting from the missing CA extension is
 	 * ignored as well as validity time errors. The latter are checked manually later on.
-	 * @param proxyChain
-	 * @param errors
-	 * @param unresolvedExtensions
-	 * @throws CertificateException
+	 * @param proxyChain proxy chain
+	 * @param trustAnchor trust anchor
+	 * @param errors errors
+	 * @param unresolvedExtensions unresolved extensions
+	 * @throws CertificateException certificate exception
 	 */
 	protected void checkProxyChainWithBC(X509Certificate[] proxyChain, 
 			Set<TrustAnchor> trustAnchor, 
@@ -380,10 +389,11 @@ public class BCCertPathValidator
 	 * Performs a validation loop of the proxy chain checking each pair in chain
 	 * for the rules not otherwise verified by the base check. Additionally chain length
 	 * restriction is verified.
-	 * @param proxyChain
-	 * @param errors
-	 * @param unresolvedExtensions
-	 * @throws CertificateException
+	 * @param proxyChain proxy chain
+	 * @param errors errors
+	 * @param unresolvedExtensions unresolved extensions
+	 * @param validDate valid date
+	 * @throws CertificateException certificate exception
 	 */
 	protected void checkProxyChainMain(X509Certificate[] proxyChain, 
 			List<ValidationError> errors, Set<String> unresolvedExtensions, Date validDate)
@@ -454,6 +464,10 @@ public class BCCertPathValidator
 	 * @param proxyCert certificate to be checked
 	 * @param errors out arg - list of errors found
 	 * @param position position in original chain to be used in error reporting
+	 * @param proxyChain proxy chain
+	 * @param validationTime validation time
+	 * @throws CertPathValidatorException certificate path validator exception
+	 * @throws CertificateParsingException certificate parsing exception
 	 */
 	protected void checkPairWithProxy(X509Certificate issuerCert, X509Certificate proxyCert, 
 			List<ValidationError> errors, int position, X509Certificate[] proxyChain, Date validationTime)

--- a/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/NonValidatingCertPathBuilder.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/NonValidatingCertPathBuilder.java
@@ -69,7 +69,9 @@ public class NonValidatingCertPathBuilder
 	 * @param pkixParams PKIXBuilderParameters object containing certificates
 	 * to build the CertPath
 	 * @param target Target certificate for the path
-	 * @throws ValidationErrorException 
+	 * @param origChain original chain
+	 * @return certificate paths
+	 * @throws ValidationErrorException validation error exception 
 	 */
 	public List<CertPath> buildPath(ExtendedPKIXBuilderParameters pkixParams, 
 			X509Certificate target, X509Certificate[] origChain) throws ValidationErrorException

--- a/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/PlainCRLValidator.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/PlainCRLValidator.java
@@ -32,7 +32,7 @@ import eu.emi.security.authn.x509.impl.RevocationParametersExt;
  * Important note: this class extends {@link AbstractValidator}. Those classes are in fact 
  * unrelated, but as Java deosn't support multi inheritance we still extend it.
  * Extensions of this class must initialize {@link AbstractValidator} with its 
- * {@link AbstractValidator#init(eu.emi.security.authn.x509.helpers.trust.TrustAnchorStore, PlainCRLStoreSpi, eu.emi.security.authn.x509.ProxySupport, eu.emi.security.authn.x509.RevocationParameters)}
+ * {@link AbstractValidator#init(eu.emi.security.authn.x509.helpers.trust.TrustAnchorStore, eu.emi.security.authn.x509.helpers.crl.AbstractCRLStoreSPI, eu.emi.security.authn.x509.ProxySupport, eu.emi.security.authn.x509.RevocationParameters)}
  * method.
  * </p><p>
  * This class is thread-safe.

--- a/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/bc/CertPathValidatorUtilities.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/bc/CertPathValidatorUtilities.java
@@ -49,7 +49,7 @@ import eu.emi.security.authn.x509.ValidationErrorCode;
 import eu.emi.security.authn.x509.helpers.pkipath.SimpleValidationErrorException;
 
 /**
- * Exposes otherwise hidden methods from {@link CertPathValidatorUtilities} plus in some
+ * Exposes otherwise hidden methods from {@link org.bouncycastle.jce.provider.CertPathValidatorUtilities} plus in some
  * cases fixes bugs plus produces errors in the desired format.
  * @author K. Benedyczak
  */
@@ -114,7 +114,7 @@ public class CertPathValidatorUtilities extends
 	 * @param paramsPKIX The extended PKIX parameters.
 	 * @param completeCRL The complete CRL the delta CRL is for.
 	 * @return A <code>Set</code> of <code>X509CRL</code>s with delta CRLs.
-	 * @throws AnnotatedException if an exception occurs while picking the
+	 * @throws SimpleValidationErrorException if an exception occurs while picking the
 	 *                 delta CRLs.
 	 */
 	protected static Set<X509CRL> getDeltaCRLs2(Date currentDate,

--- a/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/bc/FixedBCPKIXCertPathReviewer.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/bc/FixedBCPKIXCertPathReviewer.java
@@ -178,7 +178,8 @@ public class FixedBCPKIXCertPathReviewer extends PKIXCertPathReviewer
     
     /**
      * Creates a PKIXCertPathReviewer and initializes it with the given {@link CertPath} and {@link PKIXParameters} params
-     * @param certPath the {@link CertPath} to validate     * @param params the {@link PKIXParameters} to use
+     * @param certPath the {@link CertPath} to validate
+     * @param params the {@link PKIXParameters} to use
      * @throws CertPathReviewerException if the certPath is empty
      */
     public FixedBCPKIXCertPathReviewer(CertPath certPath, ExtPKIXParameters params)

--- a/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/bc/RFC3280CertPathUtilitiesHelper.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/pkipath/bc/RFC3280CertPathUtilitiesHelper.java
@@ -80,7 +80,7 @@ public class RFC3280CertPathUtilitiesHelper extends RFC3280CertPathUtilities
 	 * @param workingPublicKey The public key of the issuer certificate
 	 *                <code>sign</code>.
 	 * @param certPathCerts The certificates of the certification path.
-	 * @throws AnnotatedException if the certificate is revoked or the
+	 * @throws SimpleValidationErrorException if the certificate is revoked or the
 	 *                 status cannot be checked or some error occurs.
 	 */
 	protected static void checkCRLs2(ExtPKIXParameters paramsPKIX, X509Certificate cert,

--- a/src/main/java/eu/emi/security/authn/x509/helpers/proxy/ProxyACExtension.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/proxy/ProxyACExtension.java
@@ -30,8 +30,8 @@ public class ProxyACExtension extends ASN1Object
 	/**
 	 * Generates a new ProxyACExtension object form the byte array
 	 * 
-	 * @param bytes 
-	 * @throws IOException
+	 * @param bytes bytes
+	 * @throws IOException IO exception
 	 */
 	public ProxyACExtension(byte[] bytes) throws IOException
 	{

--- a/src/main/java/eu/emi/security/authn/x509/helpers/proxy/ProxyAddressRestrictionData.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/proxy/ProxyAddressRestrictionData.java
@@ -162,10 +162,10 @@ public class ProxyAddressRestrictionData extends ASN1Object
 
 	/**
 	 * Creates an instance of the extension of the given type from a certificate.
-	 * @param certificate
+	 * @param certificate certificate
 	 * @param source whether to create object representing the source restriction (if true) or target (if value is false).
 	 * @return null if the certificate does not have the required extension, initialized object otherwise.
-	 * @throws IOException
+	 * @throws IOException IO exception
 	 */
 	public static ProxyAddressRestrictionData getInstance(X509Certificate certificate, boolean source) 
 			throws IOException

--- a/src/main/java/eu/emi/security/authn/x509/helpers/proxy/ProxyCSRImpl.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/proxy/ProxyCSRImpl.java
@@ -20,7 +20,7 @@ public class ProxyCSRImpl implements ProxyCSR
 	private PrivateKey pk;
 	
 	/**
-	 * @param csr
+	 * @param csr PKCS10 certification request
 	 * @param pk use null if PrivateKey was not generated
 	 */
 	public ProxyCSRImpl(PKCS10CertificationRequest csr, PrivateKey pk)

--- a/src/main/java/eu/emi/security/authn/x509/helpers/proxy/ProxyCertInfoExtension.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/proxy/ProxyCertInfoExtension.java
@@ -111,7 +111,7 @@ public class ProxyCertInfoExtension extends ASN1Object
 	 * 
 	 * @param seq
 	 *                The sequence containing the extension.
-	 * @throws IOException 
+	 * @throws IOException IO exception
 	 */
 	public ProxyCertInfoExtension(ASN1Sequence seq) throws IOException
 	{
@@ -147,9 +147,9 @@ public class ProxyCertInfoExtension extends ASN1Object
 	 * Tries to generate {@link ProxyCertInfoExtension} object from the 
 	 * provided certificate. Returns null if the certificate has no proxy extension
 	 * (draft or rfc).
-	 * @param cert
+	 * @param cert certificate
 	 * @return instance intialized from the certificate object
-	 * @throws IOException 
+	 * @throws IOException IO exception
 	 */
 	public static ProxyCertInfoExtension getInstance(X509Certificate cert) throws IOException
 	{

--- a/src/main/java/eu/emi/security/authn/x509/helpers/proxy/ProxyGeneratorHelper.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/proxy/ProxyGeneratorHelper.java
@@ -68,11 +68,11 @@ public class ProxyGeneratorHelper
 	 * @param privateKey key to sign the proxy
 	 * @return a newly created proxy certificate, wrapped together with a private key 
 	 * if it was also generated.
-	 * @throws InvalidKeyException
-	 * @throws SignatureException
-	 * @throws NoSuchAlgorithmException
-	 * @throws IOException 
-	 * @throws CertificateEncodingException
+	 * @throws InvalidKeyException invalid key exception
+	 * @throws SignatureException signature exception
+	 * @throws NoSuchAlgorithmException no such algorithm exception
+	 * @throws CertificateParsingException certificate parsing exception
+	 * @throws IOException IO exception
 	 */
 	public ProxyCertificate generate(ProxyCertificateOptions param,
 			PrivateKey privateKey) throws InvalidKeyException,
@@ -90,10 +90,11 @@ public class ProxyGeneratorHelper
 	 * @param param proxy parameters
 	 * @param privateKey key to sign the proxy
 	 * @return chain with the new proxy on the first position
-	 * @throws InvalidKeyException
-	 * @throws SignatureException
-	 * @throws NoSuchAlgorithmException
-	 * @throws CertificateEncodingException
+	 * @throws InvalidKeyException invalid key exception
+	 * @throws SignatureException signature exception
+	 * @throws NoSuchAlgorithmException no such algorithm exception
+	 * @throws CertificateParsingException certificate encoding exception
+	 * @throws IOException IO exception
 	 */
 	public X509Certificate[] generate(ProxyRequestOptions param,
 			PrivateKey privateKey) throws InvalidKeyException,
@@ -176,8 +177,8 @@ public class ProxyGeneratorHelper
 	 * has the Key Usage extension then a KeyUsage is returned which contains bitwise AND of KeyUsage flags 
 	 * from all certificates.
 	 * The CA certificates are ignored in the computation.
-	 * @param chain
-	 * @return
+	 * @param chain certificate chain
+	 * @return chain key usage
 	 */
 	public static Integer getChainKeyUsage(X509Certificate[] chain)
 	{

--- a/src/main/java/eu/emi/security/authn/x509/helpers/proxy/X509v3CertificateBuilder.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/proxy/X509v3CertificateBuilder.java
@@ -106,8 +106,8 @@ public class X509v3CertificateBuilder
 	 * @param key to be used for signing
 	 * @param sigAlg oid and paramters  of the signature alg
 	 * @param sigAlgName name of the signature alg
-	 * @param provider can be null -> default will be used
-	 * @param random can be null -> default will be used
+	 * @param provider can be null -&gt; default will be used
+	 * @param random can be null -&gt; default will be used
 	 * @return generated certificate
 	 * @throws InvalidKeyException
 	 * @throws CertificateParsingException

--- a/src/main/java/eu/emi/security/authn/x509/helpers/revocation/RevocationChecker.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/revocation/RevocationChecker.java
@@ -16,8 +16,8 @@ public interface RevocationChecker
 {
 	/**
 	 * Checks revocation.
-	 * @param certitifcate
-	 * @param issuer
+	 * @param certitifcate certificate
+	 * @param issuer issuer
 	 * @return whether the revocation was successfully checked or if the status is unknown.
 	 * @throws SimpleValidationErrorException if revocation validation finished with error, in particular
 	 * also when certificate is revoked.

--- a/src/main/java/eu/emi/security/authn/x509/helpers/ssl/HostnameToCertificateChecker.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/ssl/HostnameToCertificateChecker.java
@@ -68,11 +68,14 @@ public class HostnameToCertificateChecker
 	
 	/**
 	 * 
+	 * @param result result
+	 * @param hostname hostname
+	 * @param certificate certificate
 	 * @return true iff a dNSName in altName was found (not if the matching was successful)
 	 * RFC is unclear whether IP AltName presence is also taking the precedence over CN
 	 * so we are not enforcing such a rule. 
-	 * @throws CertificateParsingException 
-	 * @throws UnknownHostException 
+	 * @throws CertificateParsingException certificate parsing exception
+	 * @throws UnknownHostException unknown host exception
 	 */
 	protected boolean checkAltNameMatching(ResultWrapper result, String hostname, 
 			X509Certificate certificate) throws CertificateParsingException, UnknownHostException

--- a/src/main/java/eu/emi/security/authn/x509/impl/AbstractHostnameToCertificateChecker.java
+++ b/src/main/java/eu/emi/security/authn/x509/impl/AbstractHostnameToCertificateChecker.java
@@ -110,6 +110,7 @@ public abstract class AbstractHostnameToCertificateChecker implements HandshakeC
 	 * @param hce the original event object
 	 * @param peerCertificate peer's certificate (for convenience) 
 	 * @param hostName peer's host name (for convenience)
+	 * @throws SSLException SSL exception
 	 */
 	protected abstract void nameMismatch(HandshakeCompletedEvent hce, X509Certificate peerCertificate,
 			String hostName) throws SSLException;

--- a/src/main/java/eu/emi/security/authn/x509/impl/CRLParameters.java
+++ b/src/main/java/eu/emi/security/authn/x509/impl/CRLParameters.java
@@ -25,7 +25,7 @@ public class CRLParameters implements CertStoreParameters, Serializable
 	/**
 	 * 
 	 * @param crls the mandatory list of CRLs. May be empty.
-	 * @param crlUpdateInterval if <=0 value is passed then CRLs are loaded only once. 
+	 * @param crlUpdateInterval if &lt;=0 value is passed then CRLs are loaded only once. 
 	 * Otherwise it is a time expressed in milliseconds between subsequent CRL updates, as
 	 * measured between the end of the last update and the start of the next.
 	 * @param remoteConnectionTimeout timeout in milliseconds of the connection and 

--- a/src/main/java/eu/emi/security/authn/x509/impl/CertificateUtils.java
+++ b/src/main/java/eu/emi/security/authn/x509/impl/CertificateUtils.java
@@ -202,7 +202,7 @@ public class CertificateUtils
 	 * Currently supported key encryption algorithms are DES and 3 DES. RC2 is unsupported.
 	 * <p>
 	 * NOTE: currently it is unsupported to load DER private keys which were encoded with openssl 
-	 * legacy encoding (e.g. with <verbatim>openssl rsa -outform der ...</verbatim>). PEM files
+	 * legacy encoding (e.g. with @verbatim openssl rsa -outform der ... @endverbatim). PEM files
 	 * in openssl legacy encoding are supported. 
 	 * @param is input stream to read encoded key from
 	 * @param format encoding type (PEM or DER)
@@ -545,6 +545,16 @@ public class CertificateUtils
 	/**
 	 * As {@link #savePrivateKey(OutputStream, PrivateKey, Encoding, String, char[], boolean)} with
 	 * the last argument equal to false 
+	 * 
+	 * @param os where to write the encoded key to 
+	 * @param pk key to save
+	 * @param format format to use
+	 * @param encryptionAlg encryption algorithm to be used. 
+	 * See {@link #savePrivateKey(OutputStream, PrivateKey, Encoding, String, char[], boolean)} documentation
+	 * for details about allowed values.
+	 * @param encryptionPassword encryption password to be used.
+	 * @throws IOException if the data can not be written 
+	 * @throws IllegalArgumentException if encryptionAlg is unsupported
 	 */
 	public static void savePrivateKey(OutputStream os, PrivateKey pk, 
 			Encoding format, String encryptionAlg, char[] encryptionPassword) 
@@ -684,6 +694,21 @@ public class CertificateUtils
 	/**
 	 * See {@link #savePEMKeystore(OutputStream, KeyStore, String, String, char[], char[], boolean)}
 	 * with the last argument equal to false.
+	 *  
+	 * @param os where to write the encoded data to
+	 * @param ks keystore to read from
+	 * @param alias alias of the private key entry in the keystore
+	 * @param encryptionAlg encryption algorithm to be used.
+	 * See {@link #savePrivateKey(OutputStream, PrivateKey, Encoding, String, char[], boolean)} documentation
+	 * for details about allowed values.
+	 * @param keyPassword password of the private key in the keystore
+	 * @param encryptionPassword encryption password to be used.
+	 * @throws IOException if the data can not be written
+	 * @throws KeyStoreException if the provided alias does not exist in the keystore 
+	 * or if it does not correspond to the private key entry.
+	 * @throws IllegalArgumentException if encriptionAlg is unsupported or alias is wrong
+	 * @throws NoSuchAlgorithmException if algorithm is not known
+	 * @throws UnrecoverableKeyException if key can not be recovered
 	 */
 	public static void savePEMKeystore(OutputStream os, KeyStore ks, String alias,
 			String encryptionAlg, char[] keyPassword, char[] encryptionPassword) 
@@ -694,8 +719,23 @@ public class CertificateUtils
 
 	/**
 	 * See {@link #savePEMKeystore(OutputStream, KeyStore, String, String, char[], char[], boolean)}.
-	 * This method allows for usinf the CANL {@link X509Credential} instead of low level
+	 * This method allows for using the CANL {@link X509Credential} instead of low level
 	 * {@link KeyStore} as argument.
+	 *  
+	 * @param os where to write the encoded data to
+	 * @param toSave CANL X509Credential to read from
+	 * @param encryptionAlg encryption algorithm to be used.
+	 * See {@link #savePrivateKey(OutputStream, PrivateKey, Encoding, String, char[], boolean)} documentation
+	 * for details about allowed values.
+	 * @param encryptionPassword encryption password to be used.
+	 * @param opensslLegacyFormat if true the key is saved in the legacy openssl format. Otherwise a 
+	 * PKCS #8 is used.
+	 * @throws IOException if the data can not be written
+	 * @throws KeyStoreException if the provided alias does not exist in the keystore 
+	 * or if it does not correspond to the private key entry.
+	 * @throws IllegalArgumentException if encriptionAlg is unsupported or alias is wrong
+	 * @throws NoSuchAlgorithmException if algorithm is not known
+	 * @throws UnrecoverableKeyException if key can not be recovered
 	 */
 	public static void savePEMKeystore(OutputStream os, X509Credential toSave,
 			String encryptionAlg, char[] encryptionPassword, boolean opensslLegacyFormat) 
@@ -713,13 +753,13 @@ public class CertificateUtils
 	 * The order from the keystore is preserved. The output stream is closed afterwards 
 	 * only if the write operation was successful (there was no exception).  
 	 *  
-	 * @param os  where to write the encoded data to
+	 * @param os where to write the encoded data to
 	 * @param ks keystore to read from
 	 * @param alias alias of the private key entry in the keystore
-	 * @param keyPassword password of the private key in the keystore
 	 * @param encryptionAlg encryption algorithm to be used.
 	 * See {@link #savePrivateKey(OutputStream, PrivateKey, Encoding, String, char[], boolean)} documentation
 	 * for details about allowed values.
+	 * @param keyPassword password of the private key in the keystore
 	 * @param encryptionPassword encryption password to be used.
 	 * @param opensslLegacyFormat if true the key is saved in the legacy openssl format. Otherwise a 
 	 * PKCS #8 is used.
@@ -727,8 +767,8 @@ public class CertificateUtils
 	 * @throws KeyStoreException if the provided alias does not exist in the keystore 
 	 * or if it does not correspond to the private key entry.
 	 * @throws IllegalArgumentException if encriptionAlg is unsupported or alias is wrong
-	 * @throws NoSuchAlgorithmException 
-	 * @throws UnrecoverableKeyException 
+	 * @throws NoSuchAlgorithmException if algorithm is not known
+	 * @throws UnrecoverableKeyException if key can not be recovered
 	 */
 	public static void savePEMKeystore(OutputStream os, KeyStore ks, String alias,
 			String encryptionAlg, char[] keyPassword, char[] encryptionPassword, boolean opensslLegacyFormat) 

--- a/src/main/java/eu/emi/security/authn/x509/impl/DirectoryCertChainValidator.java
+++ b/src/main/java/eu/emi/security/authn/x509/impl/DirectoryCertChainValidator.java
@@ -50,13 +50,13 @@ public class DirectoryCertChainValidator extends PlainCRLValidator
 	 * paths or URLs
 	 * @param encoding Whether certificates in the store are stored as PEM or DER files. Note that the
 	 * whole store must be consistent.
-	 * @param truststoreUpdateInterval truststore update interval in milliseconds. Use a <= 0 value to disable automatic updates.
-	 * @param connectionTimeoutCA connection timeout in ms for downloading remote CA certificates, >= 0. 0 means infinite timeout. 
+	 * @param truststoreUpdateInterval truststore update interval in milliseconds. Use a &lt;= 0 value to disable automatic updates.
+	 * @param connectionTimeoutCA connection timeout in ms for downloading remote CA certificates, &gt;= 0. 0 means infinite timeout. 
 	 * @param diskCache directory path, where the remote CA certificates shall be cached 
 	 * after downloading. Can be null if cache shall not be used.
 	 * @param params common validator settings (revocation, initial listeners, proxy support, ...)
-	 * @throws IOException 
-	 * @throws KeyStoreException 
+	 * @throws IOException IO exception
+	 * @throws KeyStoreException key store exception
 	 */
 	public DirectoryCertChainValidator(List<String> trustedLocations, Encoding encoding,
 			long truststoreUpdateInterval, int connectionTimeoutCA, 
@@ -78,12 +78,12 @@ public class DirectoryCertChainValidator extends PlainCRLValidator
 	 * paths or URLs
 	 * @param encoding Whether certificates in the store are stored as PEM or DER files. Note that the
 	 * whole store must be consistent.
-	 * @param truststoreUpdateInterval truststore update interval in milliseconds. Use a <= 0 value to disable automatic updates.
-	 * @param connectionTimeoutCA connection timeout in ms for downloading remote CA certificates, >= 0. 0 means infinite timeout. 
+	 * @param truststoreUpdateInterval truststore update interval in milliseconds. Use a &lt;= 0 value to disable automatic updates.
+	 * @param connectionTimeoutCA connection timeout in ms for downloading remote CA certificates, &gt;= 0. 0 means infinite timeout. 
 	 * @param diskCache directory path, where the remote CA certificates shall be cached 
 	 * after downloading. Can be null if cache shall not be used.
-	 * @throws IOException 
-	 * @throws KeyStoreException 
+	 * @throws IOException IO exception
+	 * @throws KeyStoreException key store exception
 	 */
 	public DirectoryCertChainValidator(List<String> trustedLocations, Encoding encoding,
 			long truststoreUpdateInterval, int connectionTimeoutCA, 
@@ -111,8 +111,8 @@ public class DirectoryCertChainValidator extends PlainCRLValidator
 	 * path or URL.
 	 * @param diskCache directory path, where the remote CA certificates shall be cached 
 	 * after downloading. Can be null if cache shall not be used.
-	 * @throws IOException 
-	 * @throws KeyStoreException 
+	 * @throws IOException IO exception
+	 * @throws KeyStoreException key store exception
 	 */
 	public DirectoryCertChainValidator(String trustedLocation, String crlLocation, 
 			String diskCache) throws KeyStoreException, IOException 
@@ -159,6 +159,7 @@ public class DirectoryCertChainValidator extends PlainCRLValidator
 	/**
 	 * Sets new trusted locations. See constructor argument description
 	 * for details.
+	 * @param trustedLocations trusted certificate locations
 	 */
 	public void setTruststorePaths(List<String> trustedLocations)
 	{

--- a/src/main/java/eu/emi/security/authn/x509/impl/HostnameMismatchCallback.java
+++ b/src/main/java/eu/emi/security/authn/x509/impl/HostnameMismatchCallback.java
@@ -22,6 +22,7 @@ public interface HostnameMismatchCallback
 	 * @param socket the socket
 	 * @param peerCertificate peer's certificate (for convenience) 
 	 * @param hostName peer's host name (for convenience)
+	 * @throws SSLException SSL exception
 	 */
 	public void nameMismatch(SSLSocket socket, X509Certificate peerCertificate,
 			String hostName) throws SSLException;

--- a/src/main/java/eu/emi/security/authn/x509/impl/InMemoryKeystoreCertChainValidator.java
+++ b/src/main/java/eu/emi/security/authn/x509/impl/InMemoryKeystoreCertChainValidator.java
@@ -83,7 +83,8 @@ public class InMemoryKeystoreCertChainValidator extends PlainCRLValidator
 
 	/**
 	 * Changes the current trust store.
-	 * @throws KeyStoreException 
+	 * @param ks key store
+	 * @throws KeyStoreException key store exception
 	 */
 	public synchronized void setTruststore(KeyStore ks) throws KeyStoreException
 	{

--- a/src/main/java/eu/emi/security/authn/x509/impl/KeystoreCredential.java
+++ b/src/main/java/eu/emi/security/authn/x509/impl/KeystoreCredential.java
@@ -161,8 +161,8 @@ public class KeystoreCredential extends AbstractX509Credential
 	
 	/**
 	 * Tries to autodetect keystore type.
-	 * @param ksPath
-	 * @param ksPassword
+	 * @param ksPath key store path
+	 * @param ksPassword key store password
 	 * @return Detected type
 	 * @throws IOException if error occurred when reading the file
 	 * @throws KeyStoreException if autodetection failed

--- a/src/main/java/eu/emi/security/authn/x509/impl/OpensslCertChainValidator.java
+++ b/src/main/java/eu/emi/security/authn/x509/impl/OpensslCertChainValidator.java
@@ -54,7 +54,7 @@ public class OpensslCertChainValidator extends AbstractValidator
 	 * @param namespaceMode specifies how certificate namespaces should be handled
 	 * @param updateInterval specifies in miliseconds how often the directory should be 
 	 * checked for updates. The files are reloaded only if their modification timestamp
-	 * was changed since last load. Use a <= 0 value to disable automatic updates.
+	 * was changed since last load. Use a &lt;= 0 value to disable automatic updates.
 	 * @param params common validator settings (revocation, initial listeners, proxy support, ...) 
 	 */
 	public OpensslCertChainValidator(String directory, NamespaceCheckingMode namespaceMode, 
@@ -74,7 +74,7 @@ public class OpensslCertChainValidator extends AbstractValidator
 	 * @param namespaceMode specifies how certificate namespaces should be handled
 	 * @param updateInterval specifies in miliseconds how often the directory should be 
 	 * checked for updates. The files are reloaded only if their modification timestamp
-	 * was changed since last load. Use a <= 0 value to disable automatic updates.
+	 * was changed since last load. Use a &lt;= 0 value to disable automatic updates.
 	 * @param params common validator settings (revocation, initial listeners, proxy support, ...) 
 	 */
 	public OpensslCertChainValidator(String directory, boolean openssl1Mode, NamespaceCheckingMode namespaceMode, 
@@ -93,7 +93,7 @@ public class OpensslCertChainValidator extends AbstractValidator
 	 * @param namespaceMode specifies how certificate namespaces should be handled
 	 * @param updateInterval specifies in miliseconds how often the directory should be 
 	 * checked for updates. The files are reloaded only if their modification timestamp
-	 * was changed since last load. Use a <= 0 value to disable automatic updates.
+	 * was changed since last load. Use a &lt;= 0 value to disable automatic updates.
 	 * @param params common validator settings (revocation, initial listeners, proxy support, ...)
 	 * @param lazyMode if true then certificates, CRLs and namespace definitions are loaded on-demand
 	 *  (with in-memory caching). If false then the whole truststore contents is loaded at startup and kept in memory. 

--- a/src/main/java/eu/emi/security/authn/x509/impl/OpensslNameUtils.java
+++ b/src/main/java/eu/emi/security/authn/x509/impl/OpensslNameUtils.java
@@ -34,7 +34,7 @@ public class OpensslNameUtils
 	/**
 	 * Holds mappings of labels which occur in the wild but are output differently by OpenSSL.
 	 * Also useful to have a uniform representation when creating a normalized form.
-	 * Note that in some cases OpenSSL doesn't have a label -> then an oid is used.
+	 * Note that in some cases OpenSSL doesn't have a label -&gt; then an oid is used.
 	 */
 	public static final Map<String, String> NORMALIZED_LABELS = new HashMap<String, String>();
 	
@@ -72,7 +72,7 @@ public class OpensslNameUtils
 	 * Please note that this normalization is far from being perfect: non-ascii characters 
 	 * encoded in hex are not lower-cased, it may happen that some tokens are not in the map, 
 	 * values containing '/TOKEN=' as a substring will be messed up.
-	 * @param legacyDN
+	 * @param legacyDN legacy DN
 	 * @return normalized string (hopefully) suitable for the string comparison
 	 */
 	public static String normalize(String legacyDN)
@@ -100,7 +100,7 @@ public class OpensslNameUtils
 	
 	/**
 	 * @see #opensslToRfc2253(String, boolean) with second arg equal to false
-	 * @param inputDN
+	 * @param inputDN input DN
 	 * @return RFC 2253 representation of the input
 	 * @deprecated This method is not planned for removal but it is marked as deprecated as it is highly unreliable
 	 * and you should update your code not to use openssl style DNs at all
@@ -120,7 +120,7 @@ public class OpensslNameUtils
 	 * <li> all resulting parts which have no '=' sign inside are glued with the previous element
 	 * <li> parts are output with ',' as a separator in reversed order.
 	 * </ol>
-	 * @param inputDN
+	 * @param inputDN input DN
 	 * @param withWildcards whether '*' wildcards need to be recognized
 	 * @return RFC 2253 representation of the input
 	 * @deprecated This method is not planned for removal but it is marked as deprecated as it is highly unreliable
@@ -169,7 +169,7 @@ public class OpensslNameUtils
 	 *  <li> it much more problematic to perform an opposite translation as OpenSSL format is highly ambiguous.
 	 *  <li> it is <b>STRONGLY</b> suggested not to use this format anywhere, especially in security setups, as 
 	 *  many different DNs has the same OpenSSL representation, and also not to use this method.
-	 * <li>
+	 * </ul>
 	 * Additionally there is a possibility to turn on the "Globus" compatible mode. In this mode this method
 	 * behaves more similarly to the one provided by the COG Jglobus. The basic difference is that RDNs containing 
 	 * multiple AVAs are are concatenated with '+' not with '/'.
@@ -188,6 +188,7 @@ public class OpensslNameUtils
 	 *  openssl 1.0.0i uses 'id-pda-countryOfResidence', while this method will output 'CountryOfResidence'). 
 	 * </ul> 
 	 * @param srcDn input in RFC 2253 format or similar
+	 * @param globusFlavouring globus flavouring
 	 * @return openssl format encoded input.
 	 * @since 1.1.0
 	 */

--- a/src/main/java/eu/emi/security/authn/x509/impl/SocketFactoryCreator.java
+++ b/src/main/java/eu/emi/security/authn/x509/impl/SocketFactoryCreator.java
@@ -101,6 +101,9 @@ public class SocketFactoryCreator
 	 * using {@link SecureRandom} implementation as the last argument. Note that this
 	 * method might block if the machine has not enough system entropy. It is not suggested to use
 	 * this method for setting up automatic test environments, however it is suitable for production setups.
+	 * @param c credential to use for the server socket
+	 * @param v validator to use for client's validation
+	 * @return configured {@link SSLServerSocketFactory}
 	 */
 	public static SSLServerSocketFactory getServerSocketFactory(X509Credential c, 
 			X509CertChainValidator v)
@@ -127,6 +130,9 @@ public class SocketFactoryCreator
 	 * using {@link SecureRandom} implementation as the last argument. Note that this
 	 * method might block if the machine has not enough system entropy. It is not suggested to use
 	 * this method for setting up automatic test environments, however it is suitable for production setups.
+	 * @param c credential to use for the client socket
+	 * @param v validator to use for server's validation
+	 * @return configured {@link SSLSocketFactory}
 	 */
 	public static SSLSocketFactory getSocketFactory(X509Credential c, X509CertChainValidator v)
 	{

--- a/src/main/java/eu/emi/security/authn/x509/impl/X500NameUtils.java
+++ b/src/main/java/eu/emi/security/authn/x509/impl/X500NameUtils.java
@@ -265,6 +265,7 @@ public class X500NameUtils
 	 * constructor.    
 	 * @param rfcDn RFC 2253 DN
 	 * @return the created object
+	 * @throws IOException IO exception
 	 */
 	public static X500Principal getX500Principal(String rfcDn) throws IOException
 	{

--- a/src/main/java/eu/emi/security/authn/x509/proxy/BaseProxyCertificateOptions.java
+++ b/src/main/java/eu/emi/security/authn/x509/proxy/BaseProxyCertificateOptions.java
@@ -625,7 +625,7 @@ public abstract class BaseProxyCertificateOptions
 	/**
 	 * Sets Attribute certificates, which will be added as the VOMS extensions to the generated proxy.
 	 * @param ac to be set
-	 * @throws IOException 
+	 * @throws IOException IO exception
 	 */
 	public void setAttributeCertificates(AttributeCertificate[] ac) throws IOException
 	{
@@ -638,7 +638,7 @@ public abstract class BaseProxyCertificateOptions
 	/**
 	 * 
 	 * @return Attribute certificates or null if was not set
-	 * @throws IOException 
+	 * @throws IOException IO exception
 	 */
 	public AttributeCertificate[] getAttributeCertificates() throws IOException
 	{

--- a/src/main/java/eu/emi/security/authn/x509/proxy/ProxyCSRGenerator.java
+++ b/src/main/java/eu/emi/security/authn/x509/proxy/ProxyCSRGenerator.java
@@ -80,10 +80,10 @@ public class ProxyCSRGenerator
 	 * 
 	 * @param param request creation parameters
 	 * @return Proxy certificate signing request
-	 * @throws InvalidKeyException
-	 * @throws SignatureException
-	 * @throws NoSuchAlgorithmException
-	 * @throws CertificateEncodingException
+	 * @throws InvalidKeyException invalid key exception
+	 * @throws SignatureException signature exception
+	 * @throws NoSuchAlgorithmException no such algorithm exception
+	 * @throws CertificateEncodingException certificate encoding exception
 	 * @throws IllegalArgumentException when signingKey is null and public key was manully set
 	 */
 	public static ProxyCSR generate(ProxyCertificateOptions param) 
@@ -100,11 +100,12 @@ public class ProxyCSRGenerator
 	 * the {@link ProxyCertificateOptions} parameter contains a manually set public key.
 	 * 
 	 * @param param request creation parameters
+	 * @param signingKey private key
 	 * @return Proxy certificate signing request
-	 * @throws InvalidKeyException
-	 * @throws SignatureException
-	 * @throws NoSuchAlgorithmException
-	 * @throws CertificateEncodingException
+	 * @throws InvalidKeyException invalid key exception
+	 * @throws SignatureException signature exception
+	 * @throws NoSuchAlgorithmException no such algorithm exception
+	 * @throws CertificateEncodingException certificate encoding exception
 	 * @throws IllegalArgumentException when signingKey is null and public key was manually set
 	 */
 	public static ProxyCSR generate(ProxyCertificateOptions param, PrivateKey signingKey) 

--- a/src/main/java/eu/emi/security/authn/x509/proxy/ProxyCertificateOptions.java
+++ b/src/main/java/eu/emi/security/authn/x509/proxy/ProxyCertificateOptions.java
@@ -33,6 +33,7 @@ public class ProxyCertificateOptions extends BaseProxyCertificateOptions
 	/**
 	 * Create a new proxy cert based on the parent cert chain.
 	 * Useful when locally creating a proxy from existing cert chain.
+	 * @param parentCertChain parent certificate chain
 	 */
 	public ProxyCertificateOptions(X509Certificate[] parentCertChain)
 	{

--- a/src/main/java/eu/emi/security/authn/x509/proxy/ProxyChainInfo.java
+++ b/src/main/java/eu/emi/security/authn/x509/proxy/ProxyChainInfo.java
@@ -101,6 +101,7 @@ public class ProxyChainInfo
 	 * The type of the proxy chain chain is returned. If chain contains
 	 * different types then MIXED type is returned.
 	 * @return the type of the chain
+	 * @throws CertificateException certificate exception
 	 */
 	public ProxyChainType getProxyType() throws CertificateException 
 	{
@@ -150,6 +151,8 @@ public class ProxyChainInfo
 	 * proxy in the chain.
 	 * @return true if the chain is limited, i.e. owner of the certificate
 	 * may not submit jobs
+	 * @throws CertificateException certificate exception
+	 * @throws IOException IO exception
 	 */
 	public boolean isLimited() throws CertificateException, IOException 
 	{

--- a/src/main/java/eu/emi/security/authn/x509/proxy/ProxyGenerator.java
+++ b/src/main/java/eu/emi/security/authn/x509/proxy/ProxyGenerator.java
@@ -35,10 +35,11 @@ public class ProxyGenerator
 	 * @param privateKey key to sign the proxy
 	 * @return a newly created proxy certificate, wrapped together with a private key 
 	 * if it was also generated.
-	 * @throws InvalidKeyException
-	 * @throws SignatureException
-	 * @throws NoSuchAlgorithmException
-	 * @throws CertificateParsingException
+	 * @throws InvalidKeyException invalid key exception
+	 * @throws SignatureException signature exception
+	 * @throws NoSuchAlgorithmException no such algorithm exception
+	 * @throws CertificateParsingException certificate parsing exception
+	 * @throws IOException IO exception
 	 */
 	public static ProxyCertificate generate(ProxyCertificateOptions param,
 			PrivateKey privateKey) throws InvalidKeyException,
@@ -55,10 +56,11 @@ public class ProxyGenerator
 	 * @param param proxy parameters
 	 * @param privateKey key to sign the proxy
 	 * @return chain with the new proxy on the first position
-	 * @throws InvalidKeyException
-	 * @throws SignatureException
-	 * @throws NoSuchAlgorithmException
-	 * @throws CertificateParsingException
+	 * @throws InvalidKeyException invalid key exception
+	 * @throws SignatureException signature exception
+	 * @throws NoSuchAlgorithmException no such algorithm exception
+	 * @throws CertificateParsingException certificate parsing exception
+	 * @throws IOException IO exception
 	 */
 	public static X509Certificate[] generate(ProxyRequestOptions param,
 			PrivateKey privateKey) throws InvalidKeyException,

--- a/src/main/java/eu/emi/security/authn/x509/proxy/ProxyRequestOptions.java
+++ b/src/main/java/eu/emi/security/authn/x509/proxy/ProxyRequestOptions.java
@@ -29,6 +29,11 @@ public class ProxyRequestOptions extends BaseProxyCertificateOptions
 	 * a certificate chain. Used for example when creating a proxy
 	 * certificate on the client side from certificate request coming from a
 	 * service.
+	 * @param parentCertChain parent certificate chain
+	 * @param certReq certificate request
+	 * @throws InvalidKeyException invalid key exception
+	 * @throws NoSuchAlgorithmException no such algorithm exception
+	 * @throws NoSuchProviderException no such provider exception
 	 */
 	public ProxyRequestOptions(X509Certificate[] parentCertChain,
 			PKCS10CertificationRequest certReq)


### PR DESCRIPTION
Java 8's javadoc is much more strict, and javadoc problems now gives errors instead of warnings, which causes the build to fail. This is an attempt to fix the build.

In this patch many of the javadoc comments are quite minimalistic and don't really provide proper documentation. Someone more familiar with the code can certainly improve them. But these changes made it pass the compilation.