### PR TITLE
Relax condition due to Debian BTS 834958

### DIFF
--- a/src/test/java/eu/emi/security/authn/x509/impl/OpensslValidatorStressTest.java
+++ b/src/test/java/eu/emi/security/authn/x509/impl/OpensslValidatorStressTest.java
@@ -82,7 +82,7 @@ public class OpensslValidatorStressTest
 				OPERATIONS*1000.0/linearDuration + "ops");
 		System.out.println("Parallel duration: " + parallelDuration + "ms, " + 
 				OPERATIONS*1000.0/parallelDuration + "ops");
-		assertThat(1.4*parallelDuration < linearDuration, is(true));
+		assertThat(1.2*parallelDuration < linearDuration, is(true));
 	}
 	
 	private long runValidation(int threadsNum, final int loop, final OpensslCertChainValidator validator,


### PR DESCRIPTION
The rebuild of the debian package of canl-java sometimes fail due to a test failure, as reported here:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=834958

The failing test runs the same task first sequentially and then in parallel and checks that the parallel run is at least 1.4 times faster than the sequential. In the logs provided in the Debian bug report the ratio is 1.282 and 1.325 respectively, and the test fails. It is not clear where the number 1.4 used in the test come from.

I can not reproduce the error locally on my machine, but I expect that the result of this test is strongly dependent of on what hardware the test is run.

This PR proposes the change the vlaue used in the test to 1.2.
