### PR TITLE
fix stale trust anchor on SHA-1 to SHA-256 migration.

### DIFF
--- a/src/main/java/eu/emi/security/authn/x509/helpers/trust/DirectoryTrustAnchorStore.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/trust/DirectoryTrustAnchorStore.java
@@ -43,7 +43,6 @@ public class DirectoryTrustAnchorStore extends TimedTrustAnchorStoreBase
 	private final PlainStoreUtils utils;
 	private final int connTimeout;
 	private final String cacheDir;
-	protected Set<TrustAnchorExt> anchors;
 	protected Map<URL, TrustAnchorExt> locations2anchors;
 	protected Encoding encoding;
 
@@ -66,7 +65,6 @@ public class DirectoryTrustAnchorStore extends TimedTrustAnchorStoreBase
 			throw new IllegalArgumentException("Remote connection timeout must be a non negative number");
 		this.connTimeout = connectionTimeout;
 		this.cacheDir = diskCache;
-		anchors = new HashSet<TrustAnchorExt>();
 		locations2anchors = new HashMap<URL, TrustAnchorExt>();
 		this.encoding = encoding;
 		if (!noFirstUpdate)
@@ -158,7 +156,6 @@ public class DirectoryTrustAnchorStore extends TimedTrustAnchorStoreBase
 		}
 		synchronized(this)
 		{
-			anchors.addAll(tmpAnchors);
 			locations2anchors.putAll(tmpLoc2anch);
 		}
 	}
@@ -175,7 +172,6 @@ public class DirectoryTrustAnchorStore extends TimedTrustAnchorStoreBase
 			Entry<URL, TrustAnchorExt> entry = itMain.next();
 			if (!utils.isPresent(entry.getKey()))
 			{
-				anchors.remove(entry.getValue());
 				itMain.remove();
 			}
 		}
@@ -203,16 +199,16 @@ public class DirectoryTrustAnchorStore extends TimedTrustAnchorStoreBase
 	public synchronized Set<TrustAnchor> getTrustAnchors()
 	{
 		Set<TrustAnchor> ret = new HashSet<TrustAnchor>();
-		ret.addAll(anchors);
+		ret.addAll(locations2anchors.values());
 		return ret;
 	}
 
 	@Override
 	public synchronized X509Certificate[] getTrustedCertificates()
 	{
-		X509Certificate[] ret = new X509Certificate[anchors.size()];
+		X509Certificate[] ret = new X509Certificate[locations2anchors.size()];
 		int i=0;
-		for (TrustAnchor ta: anchors)
+		for (TrustAnchor ta: locations2anchors.values())
 			ret[i++] = ta.getTrustedCert();
 		return ret;
 	}

--- a/src/main/java/eu/emi/security/authn/x509/helpers/trust/OpensslTrustAnchorStoreImpl.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/trust/OpensslTrustAnchorStoreImpl.java
@@ -82,7 +82,6 @@ public class OpensslTrustAnchorStoreImpl extends DirectoryTrustAnchorStore imple
 		
 		synchronized(this)
 		{
-			anchors.addAll(tmpAnchors);
 			locations2anchors.putAll(tmpLoc2anch);
 			if (loadEuGridPmaNs)
 				pmaNsStore.setPolicies(correctLocations);


### PR DESCRIPTION
Motivation:

Now that SHA-1 is considered broken, certificate authorities are
migrating to a SHA-2 (e.g., SHA-256) based certificates.  This includes
the certificate describing the CA itself, or that describe subordinate
CAs.

To avoid having to reissue all currently valid EECs, the new SHA-2
certificate has the same DN and identification elements
(authorityKeyIdentifier and subjectKeyIdentifier, as appropriate).
Therefore, the 'hash' (used to create the filename within the
OpenSSL-like trust-store) remains the same.

It has been reported that, after installing the new SHA-2 CA certificate,
EECs issued by such CAs are no longer considered valid:

    https://ggus.eu/index.php?mode=ticket_info&ticket_id=132205

This is caused by the CaNL in-memory trust store mistakenly containing
both the old (SHA-1) and new (SHA-2) certificates.  When validating an
EEC, that there are two matching TrustAnchor instances from the
trust-store is considered an error condition and prevents the validation
from succeeding.

As pointed out by Robert in the above ticket, the root cause is that,
although the old and new certificates have the same filename, the
certificates are not actually the same.  This difference prevents the new
certificate from evicting the old certificate.

Modification:

In part, this problem stems from the same information being held in two
places.  Therefore this patch fixes this issue simply by removing that
duplication.

Result:

Valid EECs will verify correctly after the CA that issued the EEC has
modified its certificate in a way that modifies the certificate without
changing the filename hash.