### PR TITLE
Add source version to javadoc configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.10.3</version>
 				<configuration>
+					<source>1.6</source>
 					<detectLinks />
 					<links>
 						<link>http://www.bouncycastle.org/docs/docs1.6/</link>
@@ -316,6 +317,7 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.8</version>
 				<configuration>
+					<source>1.6</source>
 					<detectLinks />
 					<links>
 						<link>http://www.bouncycastle.org/docs/docs1.5on/</link>


### PR DESCRIPTION
This fixes build failure with OpenJDK 11:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=921427
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:jar (attach-javadocs) on project canl: MavenReportException: Error while generating Javadoc: 
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/6/docs/api/ are in the unnamed module.
[ERROR] /build/1st/canl-java-2.5.0/src/main/java/eu/emi/security/authn/x509/helpers/ReaderInputStream.java:62: warning - Tag @link: reference not found: javax.activation.DataSource
[ERROR] 
[ERROR] Command line was: /usr/lib/jvm/java-11-openjdk-amd64/bin/javadoc @options @packages
```