### PR TITLE
JDK 11 javadoc

### DIFF
--- a/src/main/java/eu/emi/security/authn/x509/helpers/ReaderInputStream.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/ReaderInputStream.java
@@ -41,8 +41,8 @@ import java.nio.charset.CodingErrorAction;
  * in a {@link java.io.BufferedReader}.
  * <p>
  * {@link ReaderInputStream} implements the inverse transformation of {@link java.io.InputStreamReader};
- * in the following example, reading from <tt>in2</tt> would return the same byte
- * sequence as reading from <tt>in</tt> (provided that the initial byte sequence is legal
+ * in the following example, reading from <code>in2</code> would return the same byte
+ * sequence as reading from <code>in</code> (provided that the initial byte sequence is legal
  * with respect to the charset encoding):
  * <pre>
  * InputStream in = ...

--- a/src/main/java/eu/emi/security/authn/x509/helpers/ReaderInputStream.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/ReaderInputStream.java
@@ -59,8 +59,8 @@ import java.nio.charset.CodingErrorAction;
  * in the design of the code. This class is typically used in situations where an existing
  * API only accepts an {@link InputStream}, but where the most natural way to produce the data
  * is as a character stream, i.e. by providing a {@link Reader} instance. An example of a situation
- * where this problem may appear is when implementing the {@link javax.activation.DataSource}
- * interface from the Java Activation Framework.
+ * where this problem may appear is when implementing the <code>DataSource</code>
+ * interface from the JavaBeans Activation Framework.
  * <p>
  * Given the fact that the {@link Reader} class doesn't provide any way to predict whether the next
  * read operation will block or not, it is not possible to provide a meaningful

--- a/src/main/java/eu/emi/security/authn/x509/package-info.java
+++ b/src/main/java/eu/emi/security/authn/x509/package-info.java
@@ -1,6 +1,7 @@
 /**
  * Contains API of the library. The interfaces defined here are implemented
- * by the classes from the the <tt>eu.emi.security.authn.x509.impl</tt> package.
+ * by the classes from the the <code>eu.emi.security.authn.x509.impl</code>
+ * package.
  */
 package eu.emi.security.authn.x509;
 


### PR DESCRIPTION
Fedora is preparing to change the default Java version from 1.8 to 11. Canl-java has a few issues with the javadoc when built using OpenJDK 11.

The HTML tag \<tt\> is obsolete. Use the <code> tag instead.
The error message from javadoc in JDK 11 is:

    error: tag not supported in the generated HTML version: tt

The JavaBeans Activation Framework (JAF) is not part of the JDK any more,
so trying to make a link to it in javadoc fails:

    error: reference not found
    ... {@link javax.activation.DataSource}
