### PR TITLE
Fix order of certificates

### DIFF
--- a/src/test/java/eu/emi/security/authn/x509/impl/OpensslCertChainValidatorTest.java
+++ b/src/test/java/eu/emi/security/authn/x509/impl/OpensslCertChainValidatorTest.java
@@ -219,10 +219,10 @@ public class OpensslCertChainValidatorTest
 				.signedBy(inter1));
 
 		ValidationResult result = whenValidating(
-				root.getCertificate(),
+				serviceCertificate,
 				inter1.getCertificate(),
 				inter2.getCertificate(),
-				serviceCertificate);
+				root.getCertificate());
 
 		assertThat(result.isValid(), is(equalTo(true)));
 		assertThat(result.getErrors(), is(empty()));


### PR DESCRIPTION
Motivation:

The certificate chain (as supplied by the server) is not arbitrary, but should start with the EEC.

The server certificate chain that triggered issue #116 does not follow this prescribed order.  However, the real-world example also doesn't follow the order used in the unit-test.  Moreover, the underlying problem is present with correctly ordered certificates.

Therefore, in order to provide a minimal example that demonstrates the problem, we should use the correct certificate ordering.

Modification:

Update order to place the EEC first, intermediate CAs next and finally the root CA.

Result:

No change in behaviour; however, the certificate order more closely resembles correct behaviour.