### PR TITLE
proxy: use sha2 to generate proxy request

### DIFF
--- a/src/main/java/eu/emi/security/authn/x509/proxy/ProxyCSRGenerator.java
+++ b/src/main/java/eu/emi/security/authn/x509/proxy/ProxyCSRGenerator.java
@@ -143,8 +143,9 @@ public class ProxyCSRGenerator
 					proxySubjectName, subjectPublicKeyInfo);
 			for (Attribute attribute: attributes)
 				builder.addAttribute(attribute.getAttrType(), attribute.getAttributeValues());
-			AlgorithmIdentifier signatureAi = new AlgorithmIdentifier(OIWObjectIdentifiers.sha1WithRSA);
-			AlgorithmIdentifier hashAi = new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1);
+			AlgorithmIdentifier algorithmIdentifier = new AlgorithmIdentifier(PKCSObjectIdentifiers.sha256WithRSAEncryption);
+			AlgorithmIdentifier signatureAi = new AlgorithmIdentifier(algorithmIdentifier.getAlgorithm(), DERNull.INSTANCE);
+			AlgorithmIdentifier hashAi = new DefaultDigestAlgorithmIdentifierFinder().find(signatureAi);
 			BcRSAContentSignerBuilder csBuilder = new BcRSAContentSignerBuilder(signatureAi, hashAi);
 			AsymmetricKeyParameter pkParam = PrivateKeyFactory.createKey(signingKey.getEncoded());
 			ContentSigner signer = csBuilder.build(pkParam);


### PR DESCRIPTION
as SHA1 is banned by many OSes