### PR TITLE
add workaround bouncycastle EC algorithm name mismatch

### DIFF
--- a/src/main/java/eu/emi/security/authn/x509/helpers/CertificateHelpers.java
+++ b/src/main/java/eu/emi/security/authn/x509/helpers/CertificateHelpers.java
@@ -254,7 +254,9 @@ public class CertificateHelpers
 	public static void checkKeysMatching(PrivateKey privKey, PublicKey pubKey) throws InvalidKeyException
 	{
 		String algorithm = pubKey.getAlgorithm();
-		if (!privKey.getAlgorithm().equals(algorithm))
+
+		// REVISIT: BouncyCastle uses "ECDSA" as the private key algorithm and "EC" as the public key algorithm names for elliptic curve keys.
+		if (!privKey.getAlgorithm().equals(algorithm) && !(privKey.getAlgorithm().equals("ECDSA") && algorithm.equals("EC")))
 			throw new InvalidKeyException("Private and public keys are not matching: different algorithms");
 		
 		if (algorithm.equals("DSA"))


### PR DESCRIPTION

BouncyCastle uses "ECDSA" as the private key algorithm and "EC" as the public key algorithm names for elliptic curve keys. Thus, eu.emi.security.authn.x509.helpers.CertificateHelpers#checkKeysMatching throws an exception.

Add a workaround to allow such a mismatch.